### PR TITLE
fix EPERM bug

### DIFF
--- a/mkbox.c
+++ b/mkbox.c
@@ -203,6 +203,10 @@ int main(int argc, char **argv) {
 	ok(write, fd, buf, strlen(buf));
 	ok(close, fd);
 
+	fd = ok(open, "/proc/self/setgroups", O_WRONLY);
+	ok(write, fd, "deny", 4);
+	ok(close, fd);
+
 	sprintf(buf, "%d %d 1\n", newgid, gid);
 	fd = ok(open, "/proc/self/gid_map", O_WRONLY);
 	ok(write, fd, buf, strlen(buf));


### PR DESCRIPTION
On more recent versions of Linux, you get an EPERM on the write to /proc/self/gid_map. To fix we need to write "deny" to /proc/self/setgroups first, as per http://man7.org/linux/man-pages/man7/user_namespaces.7.html.
